### PR TITLE
BUG: Install Canon .xml files via package data.

### DIFF
--- a/setup.json
+++ b/setup.json
@@ -19,7 +19,7 @@
     "test": []
   },
   "package_data": {
-    "": ["*.jar", "*.sql", "*.xml", "*.xsl", "*.md", "*.TEMPLATE"]
+    "bref": ["resources/canons/*.xml"]
     },
   "data_files": [],
   "scripts": []


### PR DESCRIPTION
Previously an incorrect value of `package_data` was used in setup.json
which caused `python setup.py install` not to install the canon XML
files .  This change removes unused extensions in `package_data`
(xsl,jar,sql,md), and corrects this setting so that these files are
installed.